### PR TITLE
Fix onsave cwd

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -9,7 +9,7 @@ import * as path from 'path'
 import { Position, CancellationToken, CodeAction, CodeActionKind, CodeActionRequest, Command, createConnection, Diagnostic, DiagnosticSeverity, DidChangeConfigurationNotification, DidChangeWatchedFilesNotification, ErrorCodes, ExecuteCommandRequest, Files, IConnection, NotificationHandler, NotificationType, Range, RequestHandler, RequestType, ResponseError, TextDocument, TextDocumentIdentifier, TextDocuments, TextDocumentSaveReason, TextDocumentSyncKind, TextEdit, VersionedTextDocumentIdentifier, WorkspaceChange } from 'vscode-languageserver'
 import { URI } from 'vscode-uri'
 import { CLIOptions, ESLintAutoFixEdit, ESLintError, ESLintModule, ESLintProblem, ESLintReport, Is, TextDocumentSettings } from './types'
-import { getAllFixEdits, resolveModule } from './util'
+import { getAllFixEdits, getFilePath, getFileSystemPath, isUNC, resolveModule } from './util'
 declare var __webpack_require__: any
 declare var __non_webpack_require__: any
 const requireFunc = typeof __webpack_require__ === "function" ? __non_webpack_require__ : require
@@ -210,82 +210,6 @@ function convertSeverity(severity: number): DiagnosticSeverity {
     default:
       return DiagnosticSeverity.Error
   }
-}
-
-const enum CharCode {
-  /**
-   * The `\` character.
-   */
-  Backslash = 92
-}
-
-/**
- * Check if the path follows this pattern: `\\hostname\sharename`.
- *
- * @see https://msdn.microsoft.com/en-us/library/gg465305.aspx
- * @return A boolean indication if the path is a UNC path, on none-windows
- * always false.
- */
-function isUNC(path: string): boolean {
-  if (process.platform !== 'win32') {
-    // UNC is a windows concept
-    return false
-  }
-
-  if (!path || path.length < 5) {
-    // at least \\a\b
-    return false
-  }
-
-  let code = path.charCodeAt(0)
-  if (code !== CharCode.Backslash) {
-    return false
-  }
-  code = path.charCodeAt(1)
-  if (code !== CharCode.Backslash) {
-    return false
-  }
-  let pos = 2
-  let start = pos
-  for (; pos < path.length; pos++) {
-    code = path.charCodeAt(pos)
-    if (code === CharCode.Backslash) {
-      break
-    }
-  }
-  if (start === pos) {
-    return false
-  }
-  code = path.charCodeAt(pos + 1)
-  if (isNaN(code) || code === CharCode.Backslash) {
-    return false
-  }
-  return true
-}
-
-function getFileSystemPath(uri: URI): string {
-  let result = uri.fsPath
-  if (process.platform === 'win32' && result.length >= 2 && result[1] === ':') {
-    // Node by default uses an upper case drive letter and ESLint uses
-    // === to compare pathes which results in the equal check failing
-    // if the drive letter is lower case in th URI. Ensure upper case.
-    return result[0].toUpperCase() + result.substr(1)
-  } else {
-    return result
-  }
-}
-
-function getFilePath(documentOrUri: string | TextDocument): string {
-  if (!documentOrUri) {
-    return undefined
-  }
-  let uri = Is.string(documentOrUri)
-    ? URI.parse(documentOrUri)
-    : URI.parse(documentOrUri.uri)
-  if (uri.scheme !== 'file') {
-    return undefined
-  }
-  return getFileSystemPath(uri)
 }
 
 const exitCalled = new NotificationType<[number, string], void>(

--- a/server/index.ts
+++ b/server/index.ts
@@ -772,17 +772,17 @@ function getMessage(err: any, document: TextDocument): string {
 }
 
 function validate(document: TextDocument, settings: TextDocumentSettings, publishDiagnostics = true): void {
-  let newOptions: CLIOptions = Object.assign(Object.create(null), settings.options)
-  let content = document.getText()
-  let uri = document.uri
+  const uri = document.uri
+  const content = document.getText()
+  const newOptions: CLIOptions = Object.assign(Object.create(null), settings.options)
   executeInWorkspaceDirectory(document, settings, newOptions, (file: string, options: CLIOptions) => {
-    let cli = new settings.library.CLIEngine(options)
+    const cli = new settings.library.CLIEngine(options)
     // Clean previously computed code actions.
     codeActions.delete(uri)
-    let report: ESLintReport = cli.executeOnText(content, file)
-    let diagnostics: Diagnostic[] = []
+    const report: ESLintReport = cli.executeOnText(content, file)
+    const diagnostics: Diagnostic[] = []
     if (report && report.results && Array.isArray(report.results) && report.results.length > 0) {
-      let docReport = report.results[0]
+      const docReport = report.results[0]
       if (docReport.messages && Array.isArray(docReport.messages)) {
         docReport.messages.forEach(problem => {
           if (problem) {
@@ -791,11 +791,11 @@ function validate(document: TextDocument, settings: TextDocumentSettings, publis
               // Filter out warnings when quiet mode is enabled
               return
             }
-            let diagnostic = makeDiagnostic(problem)
+            const diagnostic = makeDiagnostic(problem)
             diagnostics.push(diagnostic)
             if (settings.autoFix) {
               if (typeof cli.getRules === 'function' && problem.ruleId !== undefined && problem.fix !== undefined) {
-                let rule = cli.getRules().get(problem.ruleId)
+                const rule = cli.getRules().get(problem.ruleId)
                 if (rule !== undefined && rule.meta && typeof rule.meta.fixable == 'string') {
                   recordCodeAction(document, diagnostic, problem)
                 }


### PR DESCRIPTION
When you open a file from a directory which is not in the 'document workspace' eslint will try to load modules (pugins, includes, etc.) from that directory instead of the workspace directory, this will fail when you have custom rules, plugin depencies, etc. in your project's eslintrc.yaml. 

From the ESLint documentation:
> If you already have some text to lint, then you can use the executeOnText() method to lint that text. The linter will assume that the text is a file in the current working directory, and so will still obey any .eslintrc and .eslintignore files that may be present. Here’s an example:
(https://eslint.org/docs/developer-guide/nodejs-api#cliengineexecuteontext)

This pull request will change your current working directory as it does in the validate function which solves the above described issue :)

If anything is unclear, please let me know, and again thanks for you're awesome project!