### PR TITLE
try to resolve eslint relatively to nodePath

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -323,7 +323,9 @@ function resolveSettings(
       } else {
         directory = settings.workspaceFolder ? URI.parse(settings.workspaceFolder.uri).fsPath : undefined
       }
-      promise = resolveModule('eslint', directory, nodePath)
+      promise = resolveModule('./eslint', directory, nodePath).catch(() => {
+        return resolveModule('eslint', directory, nodePath)
+      })
       return promise.then(path => {
         let library = path2Library.get(path)
         if (!library) {


### PR DESCRIPTION
Currently, coc-eslint tries to reslove the eslint module contained in a `node_modules` folder.  This patch tries to resolve it locally first, then from the first parent-sibling `node_modules` folder.

### Motivation

Yarn 2 (soon-to-be-released) is leveraging its "Plug'n'play" concept to the next level. Basycally, it doesn't store node modules in the `node_modules` folder anymore. As a workaround for tooling depending on node modules installed as a project dependency, it creates some modules files in a folder (currently named `.vscode/pnpify/eslint`). By setting `nodePath` to this folder, the extension should be able to resolve the needed source and binaries. The VSCode extension handle it correctly, but `coc-eslint` differs a bit and don't try to resolve the path relatively to `nodePath`.
