### PR TITLE
Add option to disable autofix for specific rules

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,6 +36,7 @@ In your vim/neovim run the following command:
   ```
 - `eslint.run` - run the linter `onSave` or `onType`. The Default is `onType`.
 - `eslint.autoFixOnSave` - enables auto fix on save.
+- `eslint.autoFixSkipRules` - rules that shouldn't be autofixed.
 - `eslint.nodePath` - use this setting if an installed ESLint package can't be detected. For example `/myGlobalNodePackages/node_modules`.
 - `eslint.filetypes` - an array of language identifiers specifying the files to be validated.
 - `eslint.codeAction.disableRuleComment` - object with properties:

--- a/package.json
+++ b/package.json
@@ -113,6 +113,14 @@
           "type": "boolean",
           "default": false
         },
+        "eslint.autoFixSkipRules": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Rules that should be skipped when autofixing."
+        },
         "eslint.codeAction.disableRuleComment": {
           "scope": "resource",
           "type": "object",

--- a/server/types.ts
+++ b/server/types.ts
@@ -125,6 +125,7 @@ export interface TextDocumentSettings {
   quiet: boolean
   autoFix: boolean
   autoFixOnSave: boolean
+  autoFixSkipRules: string[]
   options: any | undefined
   run: RunValues
   nodePath: string | undefined

--- a/server/util.ts
+++ b/server/util.ts
@@ -1,7 +1,7 @@
 import * as path from 'path'
 import fastDiff from 'fast-diff'
 import { TextDocument, TextEdit } from 'vscode-languageserver'
-import { CLIOptions, Is, TextDocumentSettings } from './types'
+import { CLIOptions, ESLintProblem, Is, TextDocumentSettings } from './types'
 import { URI } from 'vscode-uri'
 import resolveFrom from 'resolve-from'
 
@@ -91,7 +91,10 @@ export function getAllFixEdits(document: TextDocument, settings: TextDocumentSet
   const uri = URI.parse(document.uri)
   if (uri.scheme != 'file') return []
   const content = document.getText()
-  const newOptions: CLIOptions = {...settings.options, fix: true}
+  const fixRule = (problem: ESLintProblem): boolean => {
+    return settings.autoFixSkipRules.indexOf(problem.ruleId) === -1;
+  }
+  const newOptions: CLIOptions = {...settings.options, fix: fixRule}
   return executeInWorkspaceDirectory(document, settings, newOptions, (filename: string, options: CLIOptions) => {
     if (!settings.validate) {
       return []

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ interface TextDocumentSettings {
   packageManager: 'npm' | 'yarn'
   autoFix: boolean
   autoFixOnSave: boolean
+  autoFixSkipRules: string[]
   quiet: boolean
   options: any | undefined
   nodePath: string | undefined
@@ -227,6 +228,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
               validate: config.get('validate', true),
               autoFix: config.get('autoFix', false),
               autoFixOnSave: config.get('autoFixOnSave', false),
+              autoFixSkipRules: config.get('autoFixSkipRules', []),
               nodePath: config.get('nodePath', undefined),
               options: config.get<Object>('options', {}),
               run: config.get('run', 'onType'),


### PR DESCRIPTION
Currently you can disable a rule entirely using `eslint.options`, but then you also lose the error/warning. There can be cases though where you still want the warning, but you do not want it to be resolved automatically.

The ESLint team has indicated that this is up to the editors/editor plugins to handle on their end: https://github.com/eslint/eslint/issues/7549#issuecomment-314047785.

This PR adds a new option that allows you to specify a list of rules that should not automatically be fixed, without preventing them from being reported.