### PR TITLE
fix eslint.nodepath support

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,6 @@
     "coc.nvim": "0.0.79",
     "eslint": "^7.9.0",
     "fast-diff": "^1.2.0",
-    "resolve-from": "^5.0.0",
     "rimraf": "^3.0.0",
     "ts-loader": "^6.2.1",
     "typescript": "^3.7.4",

--- a/server/util.ts
+++ b/server/util.ts
@@ -3,7 +3,6 @@ import fastDiff from 'fast-diff'
 import { TextDocument, TextEdit } from 'vscode-languageserver'
 import { CLIOptions, ESLintProblem, Is, TextDocumentSettings } from './types'
 import { URI } from 'vscode-uri'
-import resolveFrom from 'resolve-from'
 
 interface Change {
   start: number
@@ -144,19 +143,6 @@ export function getChange(oldStr: string, newStr: string): Change {
     }
   }
   return { start, end, newText }
-}
-
-export function resolveModule(name: string, localPath: string, globalPath: string): Promise<string> {
-  if (localPath) {
-    let path = resolveFrom.silent(localPath, name)
-    if (path) return Promise.resolve(path)
-  }
-  try {
-    let path = resolveFrom(globalPath, name)
-    return Promise.resolve(path)
-  } catch (e) {
-    return Promise.reject(e)
-  }
 }
 
 export function executeInWorkspaceDirectory(document: TextDocument, settings: TextDocumentSettings, newOptions: CLIOptions, callback: Function): TextEdit[] {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3272,11 +3272,6 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
-resolve-from@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
-  integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
-
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"


### PR DESCRIPTION
This commit replaces the way coc-eslint looks for the eslint path. The new implementation has been imported from vscode-eslint ([source](https://github.com/microsoft/vscode-eslint/blob/160dd36021ca96e87708d6c74b9cccd93b2b2558/server/src/eslintServer.ts#L760-L766)).

This should fix #77 and keep support for #54.

Note: I think there is a lot of ways to fix #77, but using the `vscode-eslint` solution should be the most robust as this extension is used a lot.