### PR TITLE
feat: use diagnostic level to control levels

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -798,11 +798,6 @@ function validate(document: TextDocument, settings: TextDocumentSettings, publis
       if (docReport.messages && Array.isArray(docReport.messages)) {
         docReport.messages.forEach(problem => {
           if (problem) {
-            const isWarning = convertSeverity(problem.severity) === DiagnosticSeverity.Warning
-            if (settings.quiet && isWarning) {
-              // Filter out warnings when quiet mode is enabled
-              return
-            }
             const diagnostic = makeDiagnostic(problem)
             diagnostics.push(diagnostic)
             if (settings.autoFix) {


### PR DESCRIPTION
Signed-off-by: Cheng JIANG <alex_cj96@foxmail.com>

I'd really like to re-open this in case someone needs it like me. I still think coc-eslint doesn't need to do exactly like vscode-eslint. Users just need to have more possibilities.

I need quiet mode because some projects don't have eslint configuration or contains bad eslint configuration. I'd be crazy if an error being thrown out everytime when I open a file...

However, quiet mode filters eslint warnings like vscode-eslint, but I really need it because it gives me more information and I can control diagnostic levels globally.