### PR TITLE
feat: upgrade from latest vscode-eslint

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,7 +56,6 @@ In your vim/neovim run the following command:
 - `eslint.validate`: An array of language ids which should be validated by ESLint. If not installed ESLint will show an error.
 - `eslint.probe`: An array of language ids for which the extension should probe if support is installed. default: `["javascript","javascriptreact","typescript","typescriptreact","html","vue","markdown"]`
 - `eslint.runtime`: The location of the node binary to run ESLint under. default: `null`
-- `eslint.runtime.execArgv`: Additional exec argv argument passed to the runtime. default: `null`
 - `eslint.debug`: Enables ESLint debug mode (same as --debug on the command line) default: `false`
 - `eslint.codeAction.disableRuleComment`: default: `{"enable":true,"location":"separateLine"}`
 - `eslint.codeAction.showDocumentation`: default: `{"enable":true}`

--- a/Readme.md
+++ b/Readme.md
@@ -29,8 +29,7 @@ In your vim/neovim run the following command:
   - `eslint.executeAutofix` Fix all auto-fixable Problems.
   - `eslint.createConfig` Create ESLint configuration.
   - `eslint.showOutputChannel` Show Output Channel.
-  - `eslint.resetLibraryExecution` Reset Library Execution Decisions.
-  - `eslint.manageLibraryExecution` Manage Library Execution.
+  - `eslint.restart` Restart ESLint Server.
   - `eslint.lintProject` Run eslint for current project, add errors to quickfix list.
 
 ## Configuration options
@@ -52,15 +51,18 @@ In your vim/neovim run the following command:
 - `eslint.quiet`: Turns on quiet mode, which ignores warnings. default: `false`
 - `eslint.onIgnoredFiles`: Whether ESLint should issue a warning on ignored files. default: `"off"`
   Valid options: ["warn","off"]
+- `eslint.useESLintClass`: Since version 7 ESLint offers a new API call ESLint. Use it even if the old CLIEngine is available. From version 8 on forward on ESLint class is available. default: `false`
 - `eslint.workingDirectories`: Working directories for files in different folders.
 - `eslint.validate`: An array of language ids which should be validated by ESLint. If not installed ESLint will show an error.
 - `eslint.probe`: An array of language ids for which the extension should probe if support is installed. default: `["javascript","javascriptreact","typescript","typescriptreact","html","vue","markdown"]`
 - `eslint.runtime`: The location of the node binary to run ESLint under. default: `null`
+- `eslint.runtime.execArgv`: Additional exec argv argument passed to the runtime. default: `null`
 - `eslint.debug`: Enables ESLint debug mode (same as --debug on the command line) default: `false`
 - `eslint.codeAction.disableRuleComment`: default: `{"enable":true,"location":"separateLine"}`
 - `eslint.codeAction.showDocumentation`: default: `{"enable":true}`
 - `eslint.codeActionsOnSave.mode`: Specifies the code action mode. Possible values are 'all' and 'problems'. default: `"all"`
   Valid options: ["all","problems"]
+- `eslint.codeActionsOnSave.rules`: The rules that should be executed when computing the code actions on save or formatting a file. Defaults to the rules configured via the ESLint configuration.
 - `eslint.format.enable`: Enables ESLint as a formatter. default: `false`
 - `eslint.lintTask.options`: Command line options applied when running the task for linting the whole workspace (see https://eslint.org/docs/user-guide/command-line-interface). default: `["."]`
 

--- a/package.json
+++ b/package.json
@@ -41,19 +41,9 @@
         "command": "eslint.showOutputChannel"
       },
       {
-        "title": "Reset Library Execution Decisions",
+        "title": "Restart ESLint Server",
         "category": "ESLint",
-        "command": "eslint.resetLibraryExecution"
-      },
-      {
-        "title": "Manage Library Execution",
-        "category": "ESLint",
-        "command": "eslint.manageLibraryExecution"
-      },
-      {
-        "title": "Run eslint for current project",
-        "category": "ESLint",
-        "command": "eslint.lintProject"
+        "command": "eslint.restart"
       }
     ],
     "configuration": {
@@ -91,7 +81,7 @@
             "null"
           ],
           "default": null,
-          "description": "The value of NODE_ENV to use when running eslint tasks."
+          "markdownDescription": "The value of `NODE_ENV` to use when running eslint tasks."
         },
         "eslint.nodePath": {
           "scope": "machine-overridable",
@@ -100,13 +90,13 @@
             "null"
           ],
           "default": null,
-          "description": "A path added to NODE_PATH when resolving the eslint module."
+          "markdownDescription": "A path added to `NODE_PATH` when resolving the eslint module."
         },
         "eslint.options": {
           "scope": "resource",
           "type": "object",
           "default": {},
-          "description": "The eslint options object to provide args normally passed to eslint when executed from a command line (see http://eslint.org/docs/developer-guide/nodejs-api#cliengine)."
+          "markdownDescription": "The eslint options object to provide args normally passed to eslint when executed from a command line (see https://eslint.org/docs/developer-guide/nodejs-api#eslint-class)."
         },
         "eslint.trace.server": {
           "scope": "window",
@@ -178,10 +168,15 @@
           "default": "off",
           "description": "Whether ESLint should issue a warning on ignored files."
         },
+        "eslint.useESLintClass": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "description": "Since version 7 ESLint offers a new API call ESLint. Use it even if the old CLIEngine is available. From version 8 on forward on ESLint class is available."
+        },
         "eslint.workingDirectories": {
           "scope": "resource",
           "type": "array",
-          "description": "Working directories for files in different folders.",
           "items": {
             "anyOf": [
               {
@@ -195,9 +190,9 @@
                     "enum": [
                       "auto",
                       "location"
-                    ]
-                  },
-                  "default": "location"
+                    ],
+                    "default": "location"
+                  }
                 },
                 "required": [
                   "mode"
@@ -236,7 +231,8 @@
                 ]
               }
             ]
-          }
+          },
+          "markdownDescription": "Specifies how the working directories ESLint is using are computed. ESLint resolves configuration files (e.g. `eslintrc`, `.eslintignore`) relative to a working directory so it is important to configure this correctly."
         },
         "eslint.validate": {
           "scope": "resource",
@@ -288,21 +284,22 @@
             "null"
           ],
           "default": null,
-          "description": "The location of the node binary to run ESLint under."
+          "markdownDescription": "The location of the node binary to run ESLint under.\n\n- When specified as a user/machine setting, the Node version from `eslint.runtime` automatically replaces the built-in version.\n- When specified as a workspace setting, `eslint.runtime` allows you to switch to use that version with the `ESLint: Select Node version` command."
+        },
+        "eslint.runtime.execArgv": {
+          "scope": "machine-overridable",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": null,
+          "markdownDescription": "Additional exec argv argument passed to the runtime. This can for example be used to control the maximum heap space using --max_old_space_size"
         },
         "eslint.debug": {
           "scope": "window",
           "type": "boolean",
           "default": false,
-          "description": "Enables ESLint debug mode (same as --debug on the command line)"
-        },
-        "eslint.execArgv": {
-          "type": "array",
-          "default": [],
-          "description": "Arguments of node used on language server start.",
-          "items": {
-            "type": "string"
-          }
+          "markdownDescription": "Enables ESLint debug mode (same as `--debug` on the command line)"
         },
         "eslint.codeAction.disableRuleComment": {
           "scope": "resource",
@@ -326,7 +323,9 @@
               "default": "separateLine",
               "description": "Configure the disable rule code action to insert the comment on the same line or a new line."
             }
-          }
+          },
+          "additionalProperties": false,
+          "markdownDescription": "Show disable lint rule in the quick fix menu."
         },
         "eslint.codeAction.showDocumentation": {
           "scope": "resource",
@@ -340,7 +339,9 @@
               "default": true,
               "description": "Show the documentation code actions."
             }
-          }
+          },
+          "additionalProperties": false,
+          "markdownDescription": "Show open lint rule documentation web page in the quick fix menu."
         },
         "eslint.codeActionsOnSave.mode": {
           "scope": "resource",
@@ -354,13 +355,47 @@
             "Only fixes reported problems that have non overlapping textual edits. This options runs a lot faster."
           ],
           "default": "all",
-          "description": "Specifies the code action mode. Possible values are 'all' and 'problems'."
+          "markdownDescription": "Specifies the code action mode. Possible values are 'all' and 'problems'."
+        },
+        "eslint.codeActionsOnSave.rules": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": null,
+          "markdownDescription": "The rules that should be executed when computing the code actions on save or formatting a file. Defaults to the rules configured via the ESLint configuration"
         },
         "eslint.format.enable": {
           "scope": "resource",
           "type": "boolean",
           "default": false,
           "description": "Enables ESLint as a formatter."
+        },
+        "eslint.rules.customizations": {
+          "items": {
+            "properties": {
+              "severity": {
+                "enum": [
+                  "downgrade",
+                  "error",
+                  "info",
+                  "default",
+                  "upgrade",
+                  "warn",
+                  "off"
+                ],
+                "type": "string"
+              },
+              "rule": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "scope": "resource",
+          "type": "array",
+          "description": "Override the severity of one or more rules reported by this extension, regardless of the project's ESLint config. Use globs to apply default severities for multiple rules."
         },
         "eslint.lintTask.options": {
           "scope": "resource",

--- a/package.json
+++ b/package.json
@@ -284,9 +284,15 @@
             "null"
           ],
           "default": null,
-          "markdownDescription": "The location of the node binary to run ESLint under.\n\n- When specified as a user/machine setting, the Node version from `eslint.runtime` automatically replaces the built-in version.\n- When specified as a workspace setting, `eslint.runtime` allows you to switch to use that version with the `ESLint: Select Node version` command."
+          "markdownDescription": "The location of the node binary to run ESLint under."
         },
-        "eslint.runtime.execArgv": {
+        "eslint.debug": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enables ESLint debug mode (same as `--debug` on the command line)"
+        },
+        "eslint.execArgv": {
           "scope": "machine-overridable",
           "type": "array",
           "items": {
@@ -294,12 +300,6 @@
           },
           "default": null,
           "markdownDescription": "Additional exec argv argument passed to the runtime. This can for example be used to control the maximum heap space using --max_old_space_size"
-        },
-        "eslint.debug": {
-          "scope": "window",
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Enables ESLint debug mode (same as `--debug` on the command line)"
         },
         "eslint.codeAction.disableRuleComment": {
           "scope": "resource",

--- a/package.json
+++ b/package.json
@@ -380,15 +380,15 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^10.12.0",
-    "coc.nvim": "^0.0.80",
+    "coc.nvim": "^0.0.81-next.7",
     "esbuild": "^0.8.29",
     "eslint": "^7.15.0",
     "rimraf": "^3.0.0",
     "typescript": "^4.1.2",
     "vscode-languageserver": "7.0.0",
-    "vscode-languageserver-protocol": "3.15.3",
-    "vscode-languageserver-textdocument": "^1.0.1",
-    "vscode-uri": "^2.1.1"
+    "vscode-languageserver-protocol": "3.16.0",
+    "vscode-languageserver-textdocument": "^1.0.2",
+    "vscode-uri": "^3.0.2"
   },
   "dependencies": {}
 }

--- a/server/diff.ts
+++ b/server/diff.ts
@@ -754,7 +754,7 @@ export class LcsDiff {
         } else {
           // We didn't actually remember enough of the history.
 
-          //Since we are quiting the diff early, we need to shift back the originalStart and modified start
+          //Since we are quitting the diff early, we need to shift back the originalStart and modified start
           //back into the boundary limits since we decremented their value above beyond the boundary limit.
           originalStart++
           modifiedStart++

--- a/server/linkedMap.ts
+++ b/server/linkedMap.ts
@@ -1,0 +1,448 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+interface Item<K, V> {
+  previous: Item<K, V> | undefined
+  next: Item<K, V> | undefined
+  key: K
+  value: V
+}
+
+export namespace Touch {
+  export const None: 0 = 0
+  export const First: 1 = 1
+  export const AsOld: 1 = Touch.First
+  export const Last: 2 = 2
+  export const AsNew: 2 = Touch.Last
+}
+
+export type Touch = 0 | 1 | 2
+
+export class LinkedMap<K, V> implements Map<K, V> {
+
+  readonly [Symbol.toStringTag] = 'LinkedMap'
+
+  private _map: Map<K, Item<K, V>>
+  private _head: Item<K, V> | undefined
+  private _tail: Item<K, V> | undefined
+  private _size: number
+
+  private _state: number
+
+  public constructor() {
+    this._map = new Map<K, Item<K, V>>()
+    this._head = undefined
+    this._tail = undefined
+    this._size = 0
+    this._state = 0
+  }
+
+  public clear(): void {
+    this._map.clear()
+    this._head = undefined
+    this._tail = undefined
+    this._size = 0
+    this._state++
+  }
+
+  public isEmpty(): boolean {
+    return !this._head && !this._tail
+  }
+
+  public get size(): number {
+    return this._size
+  }
+
+  public get first(): V | undefined {
+    return this._head?.value
+  }
+
+  public get last(): V | undefined {
+    return this._tail?.value
+  }
+
+  public has(key: K): boolean {
+    return this._map.has(key)
+  }
+
+  public get(key: K, touch: Touch = Touch.None): V | undefined {
+    const item = this._map.get(key)
+    if (!item) {
+      return undefined
+    }
+    if (touch !== Touch.None) {
+      this.touch(item, touch)
+    }
+    return item.value
+  }
+
+  public set(key: K, value: V, touch: Touch = Touch.None): this {
+    let item = this._map.get(key)
+    if (item) {
+      item.value = value
+      if (touch !== Touch.None) {
+        this.touch(item, touch)
+      }
+    } else {
+      item = { key, value, next: undefined, previous: undefined }
+      switch (touch) {
+        case Touch.None:
+          this.addItemLast(item)
+          break
+        case Touch.First:
+          this.addItemFirst(item)
+          break
+        case Touch.Last:
+          this.addItemLast(item)
+          break
+        default:
+          this.addItemLast(item)
+          break
+      }
+      this._map.set(key, item)
+      this._size++
+    }
+    return this
+  }
+
+  public delete(key: K): boolean {
+    return !!this.remove(key)
+  }
+
+  public remove(key: K): V | undefined {
+    const item = this._map.get(key)
+    if (!item) {
+      return undefined
+    }
+    this._map.delete(key)
+    this.removeItem(item)
+    this._size--
+    return item.value
+  }
+
+  public shift(): V | undefined {
+    if (!this._head && !this._tail) {
+      return undefined
+    }
+    if (!this._head || !this._tail) {
+      throw new Error('Invalid list')
+    }
+    const item = this._head
+    this._map.delete(item.key)
+    this.removeItem(item)
+    this._size--
+    return item.value
+  }
+
+  public forEach(callbackfn: (value: V, key: K, map: LinkedMap<K, V>) => void, thisArg?: any): void {
+    const state = this._state
+    let current = this._head
+    while (current) {
+      if (thisArg) {
+        callbackfn.bind(thisArg)(current.value, current.key, this)
+      } else {
+        callbackfn(current.value, current.key, this)
+      }
+      if (this._state !== state) {
+        throw new Error(`LinkedMap got modified during iteration.`)
+      }
+      current = current.next
+    }
+  }
+
+  public keys(): IterableIterator<K> {
+    const map = this
+    const state = this._state
+    let current = this._head
+    const iterator: IterableIterator<K> = {
+      [Symbol.iterator]() {
+        return iterator
+      },
+      next(): IteratorResult<K> {
+        if (map._state !== state) {
+          throw new Error(`LinkedMap got modified during iteration.`)
+        }
+        if (current) {
+          const result = { value: current.key, done: false }
+          current = current.next
+          return result
+        } else {
+          return { value: undefined, done: true }
+        }
+      }
+    }
+    return iterator
+  }
+
+  public values(): IterableIterator<V> {
+    const map = this
+    const state = this._state
+    let current = this._head
+    const iterator: IterableIterator<V> = {
+      [Symbol.iterator]() {
+        return iterator
+      },
+      next(): IteratorResult<V> {
+        if (map._state !== state) {
+          throw new Error(`LinkedMap got modified during iteration.`)
+        }
+        if (current) {
+          const result = { value: current.value, done: false }
+          current = current.next
+          return result
+        } else {
+          return { value: undefined, done: true }
+        }
+      }
+    }
+    return iterator
+  }
+
+  public entries(): IterableIterator<[K, V]> {
+    const map = this
+    const state = this._state
+    let current = this._head
+    const iterator: IterableIterator<[K, V]> = {
+      [Symbol.iterator]() {
+        return iterator
+      },
+      next(): IteratorResult<[K, V]> {
+        if (map._state !== state) {
+          throw new Error(`LinkedMap got modified during iteration.`)
+        }
+        if (current) {
+          const result: IteratorResult<[K, V]> = { value: [current.key, current.value], done: false }
+          current = current.next
+          return result
+        } else {
+          return { value: undefined, done: true }
+        }
+      }
+    }
+    return iterator
+  }
+
+  public [Symbol.iterator](): IterableIterator<[K, V]> {
+    return this.entries()
+  }
+
+  protected trimOld(newSize: number) {
+    if (newSize >= this.size) {
+      return
+    }
+    if (newSize === 0) {
+      this.clear()
+      return
+    }
+    let current = this._head
+    let currentSize = this.size
+    while (current && currentSize > newSize) {
+      this._map.delete(current.key)
+      current = current.next
+      currentSize--
+    }
+    this._head = current
+    this._size = currentSize
+    if (current) {
+      current.previous = undefined
+    }
+    this._state++
+  }
+
+  private addItemFirst(item: Item<K, V>): void {
+    // First time Insert
+    if (!this._head && !this._tail) {
+      this._tail = item
+    } else if (!this._head) {
+      throw new Error('Invalid list')
+    } else {
+      item.next = this._head
+      this._head.previous = item
+    }
+    this._head = item
+    this._state++
+  }
+
+  private addItemLast(item: Item<K, V>): void {
+    // First time Insert
+    if (!this._head && !this._tail) {
+      this._head = item
+    } else if (!this._tail) {
+      throw new Error('Invalid list')
+    } else {
+      item.previous = this._tail
+      this._tail.next = item
+    }
+    this._tail = item
+    this._state++
+  }
+
+  private removeItem(item: Item<K, V>): void {
+    if (item === this._head && item === this._tail) {
+      this._head = undefined
+      this._tail = undefined
+    }
+    else if (item === this._head) {
+      // This can only happend if size === 1 which is handle
+      // by the case above.
+      if (!item.next) {
+        throw new Error('Invalid list')
+      }
+      item.next.previous = undefined
+      this._head = item.next
+    }
+    else if (item === this._tail) {
+      // This can only happend if size === 1 which is handle
+      // by the case above.
+      if (!item.previous) {
+        throw new Error('Invalid list')
+      }
+      item.previous.next = undefined
+      this._tail = item.previous
+    }
+    else {
+      const next = item.next
+      const previous = item.previous
+      if (!next || !previous) {
+        throw new Error('Invalid list')
+      }
+      next.previous = previous
+      previous.next = next
+    }
+    item.next = undefined
+    item.previous = undefined
+    this._state++
+  }
+
+  private touch(item: Item<K, V>, touch: Touch): void {
+    if (!this._head || !this._tail) {
+      throw new Error('Invalid list')
+    }
+    if ((touch !== Touch.First && touch !== Touch.Last)) {
+      return
+    }
+
+    if (touch === Touch.First) {
+      if (item === this._head) {
+        return
+      }
+
+      const next = item.next
+      const previous = item.previous
+
+      // Unlink the item
+      if (item === this._tail) {
+        // previous must be defined since item was not head but is tail
+        // So there are more than on item in the map
+        previous!.next = undefined
+        this._tail = previous
+      }
+      else {
+        // Both next and previous are not undefined since item was neither head nor tail.
+        next!.previous = previous
+        previous!.next = next
+      }
+
+      // Insert the node at head
+      item.previous = undefined
+      item.next = this._head
+      this._head.previous = item
+      this._head = item
+      this._state++
+    } else if (touch === Touch.Last) {
+      if (item === this._tail) {
+        return
+      }
+
+      const next = item.next
+      const previous = item.previous
+
+      // Unlink the item.
+      if (item === this._head) {
+        // next must be defined since item was not tail but is head
+        // So there are more than on item in the map
+        next!.previous = undefined
+        this._head = next
+      } else {
+        // Both next and previous are not undefined since item was neither head nor tail.
+        next!.previous = previous
+        previous!.next = next
+      }
+      item.next = undefined
+      item.previous = this._tail
+      this._tail.next = item
+      this._tail = item
+      this._state++
+    }
+  }
+
+  public toJSON(): [K, V][] {
+    const data: [K, V][] = []
+
+    this.forEach((value, key) => {
+      data.push([key, value])
+    })
+
+    return data
+  }
+
+  public fromJSON(data: [K, V][]): void {
+    this.clear()
+
+    for (const [key, value] of data) {
+      this.set(key, value)
+    }
+  }
+}
+
+export class LRUCache<K, V> extends LinkedMap<K, V> {
+
+  private _limit: number
+  private _ratio: number
+
+  public constructor(limit: number, ratio: number = 1) {
+    super()
+    this._limit = limit
+    this._ratio = Math.min(Math.max(0, ratio), 1)
+  }
+
+  public get limit(): number {
+    return this._limit
+  }
+
+  public set limit(limit: number) {
+    this._limit = limit
+    this.checkTrim()
+  }
+
+  public get ratio(): number {
+    return this._ratio
+  }
+
+  public set ratio(ratio: number) {
+    this._ratio = Math.min(Math.max(0, ratio), 1)
+    this.checkTrim()
+  }
+
+  public get(key: K, touch: Touch = Touch.AsNew): V | undefined {
+    return super.get(key, touch)
+  }
+
+  public peek(key: K): V | undefined {
+    return super.get(key, Touch.None)
+  }
+
+  public set(key: K, value: V): this {
+    super.set(key, value, Touch.Last)
+    this.checkTrim()
+    return this
+  }
+
+  private checkTrim() {
+    if (this.size > this._limit) {
+      this.trimOld(Math.round(this._limit * this._ratio))
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -535,7 +535,7 @@ function realActivate(context: ExtensionContext): void {
   const eslintConfig = Workspace.getConfiguration('eslint')
   const debug = sanitize(eslintConfig.get<boolean>('debug', false) ?? false, 'boolean', false)
   const runtime = sanitize(eslintConfig.get<string | null>('runtime', null) ?? undefined, 'string', undefined)
-  const execArgv = sanitize(eslintConfig.get<string[] | null>('runtime.execArgv', null) ?? undefined, 'string', undefined)
+  const execArgv = sanitize(eslintConfig.get<string[] | null>('execArgv', null) ?? undefined, 'string', undefined)
   const nodeEnv = sanitize(eslintConfig.get('nodeEnv', null) ?? undefined, 'string', undefined)
 
   let env: { [key: string]: string | number | boolean } | undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -567,7 +567,7 @@ async function askForLibraryConfirmation(client: LanguageClient | undefined, con
   }
 
   update && update()
-  client && client.sendNotification(DidChangeConfigurationNotification.type, { settings: {} })
+  client && client.sendNotification(DidChangeConfigurationNotification.type.method, { settings: {} })
 }
 
 async function resetLibraryConfirmations(client: LanguageClient | undefined, context: ExtensionContext, update: undefined | (() => void)): Promise<void> {
@@ -613,7 +613,7 @@ async function resetLibraryConfirmations(client: LanguageClient | undefined, con
   resource2ResourceInfo.clear()
   workspaceFolder2ExecutionInfos.clear()
   update && update()
-  client && client.sendNotification(DidChangeConfigurationNotification.type, { settings: {} })
+  client && client.sendNotification(DidChangeConfigurationNotification.type.method, { settings: {} })
 }
 
 export function activate(context: ExtensionContext) {
@@ -1207,7 +1207,7 @@ function realActivate(context: ExtensionContext): void {
             diagnostics: []
           },
         }
-        let res = await Promise.resolve(client.sendRequest(CodeActionRequest.type, params))
+        let res = await Promise.resolve(client.sendRequest(CodeActionRequest.type.method, params))
         if (res && Array.isArray(res)) {
           if (CodeAction.is(res[0])) {
             await Workspace.applyEdit(res[0].edit)
@@ -1485,7 +1485,6 @@ function realActivate(context: ExtensionContext): void {
       if (!doc || !doc.attached) {
         return
       }
-      doc.forceSync()
       const textDocument: VersionedTextDocumentIdentifier = {
         uri: doc.uri,
         version: doc.version
@@ -1495,7 +1494,7 @@ function realActivate(context: ExtensionContext): void {
         arguments: [textDocument]
       }
       await client.onReady()
-      client.sendRequest(ExecuteCommandRequest.type, params).then(undefined, () => {
+      client.sendRequest(ExecuteCommandRequest.type.method, params).then(undefined, () => {
         Window.showErrorMessage('Failed to apply ESLint fixes to the document. Please consider opening an issue with steps to reproduce.')
       })
     }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,9 @@
 import path from 'path'
 import fs from 'fs'
 import {
-  workspace as Workspace, events, Document, window as Window, commands as Commands, languages as Languages, Disposable, ExtensionContext, Uri, TextDocument, CodeActionContext, Diagnostic, ProviderResult, Command, QuickPickItem,
-  WorkspaceFolder as VWorkspaceFolder, MessageItem, DiagnosticSeverity as VDiagnosticSeverity,
-  DiagnosticCollection, Range, Position,
+  workspace as Workspace, events, window as Window, commands as Commands, Disposable, ExtensionContext, Uri, TextDocument, CodeActionContext, Diagnostic, ProviderResult, Command,
+  WorkspaceFolder as VWorkspaceFolder, MessageItem,
+  Range,
   LanguageClient, LanguageClientOptions, RequestType, TransportKind, TextDocumentIdentifier, NotificationType, ErrorHandler,
   ErrorAction, CloseAction, State as ClientState, RevealOutputChannelOn,
   ServerOptions, DocumentFilter,
@@ -18,21 +18,15 @@ import {
 import {
   CodeActionKind,
   VersionedTextDocumentIdentifier,
-  ExecuteCommandParams, DidCloseTextDocumentNotification, DidOpenTextDocumentNotification, DidChangeConfigurationNotification,
+  ExecuteCommandParams, DidCloseTextDocumentNotification, DidOpenTextDocumentNotification,
   ExecuteCommandRequest,
   CodeActionRequest,
   CodeActionParams,
   CodeAction
 } from 'vscode-languageserver-protocol'
 
-import { findEslint, convert2RegExp, toOSPath, toPosixPath, Semaphore } from './utils'
+import { findEslint, convert2RegExp, toOSPath, toPosixPath } from './utils'
 import EslintTask from './task'
-
-enum ConfigurationTarget {
-  Global,
-  User,
-  Workspace
-}
 
 namespace Is {
   const toString = Object.prototype.toString
@@ -139,7 +133,7 @@ enum CodeActionsOnSaveMode {
 
 namespace CodeActionsOnSaveMode {
   export function from(value: string | undefined | null): CodeActionsOnSaveMode {
-    if (value === undefined || value === null) {
+    if (value === undefined || value === null || !Is.string(value)) {
       return CodeActionsOnSaveMode.all
     }
     switch (value.toLowerCase()) {
@@ -151,9 +145,19 @@ namespace CodeActionsOnSaveMode {
   }
 }
 
+namespace CodeActionsOnSaveRules {
+  export function from(value: string[] | undefined | null): string[] | undefined {
+    if (value === undefined || value === null || !Array.isArray(value)) {
+      return undefined
+    }
+    return value.filter(item => Is.string(item))
+  }
+}
+
 interface CodeActionsOnSaveSettings {
   enable: boolean
   mode: CodeActionsOnSaveMode
+  rules?: string[]
 }
 
 enum Validate {
@@ -186,22 +190,35 @@ namespace ESLintSeverity {
   }
 }
 
-enum ConfirmationSelection {
-  deny = 1,
-  disable = 2,
-  allow = 3,
-  alwaysAllow = 4
+enum RuleSeverity {
+  // Original ESLint values
+  info = 'info',
+  warn = 'warn',
+  error = 'error',
+  off = 'off',
+
+  // Added severity override changes
+  default = 'default',
+  downgrade = 'downgrade',
+  upgrade = 'upgrade'
+}
+
+interface RuleCustomization {
+  rule: string
+  severity: RuleSeverity
 }
 
 interface ConfigurationSettings {
   validate: Validate
   packageManager: 'npm' | 'yarn' | 'pnpm'
+  useESLintClass: boolean
   codeAction: CodeActionSettings
   codeActionOnSave: CodeActionsOnSaveSettings
   format: boolean
   quiet: boolean
   onIgnoredFiles: ESLintSeverity
   options: any | undefined
+  rulesCustomizations: RuleCustomization[]
   run: RunValues
   nodePath: string | null
   workspaceFolder: WorkspaceFolder | undefined
@@ -216,10 +233,7 @@ interface NoESLintState {
 enum Status {
   ok = 1,
   warn = 2,
-  error = 3,
-  confirmationPending = 4,
-  executionDisabled = 5,
-  executionDenied = 6
+  error = 3
 }
 
 interface StatusParams {
@@ -275,54 +289,11 @@ namespace ProbeFailedRequest {
   export const type = new RequestType<ProbeFailedParams, void, void>('eslint/probeFailed')
 }
 
-interface ESLintExecutionState {
-  libs: { [key: string]: boolean }
-}
-
-interface ExecutionParams {
-  scope: 'local' | 'global'
-  libraryPath: string
-}
-
-interface ConfirmExecutionParams extends ExecutionParams {
-  uri: string
-}
-
-enum ConfirmExecutionResult {
-  denied = 1,
-  confirmationPending = 2,
-  disabled = 3,
-  approved = 4
-}
-
-namespace ConfirmExecutionResult {
-  export function toStatus(value: ConfirmExecutionResult): Status {
-    switch (value) {
-      case ConfirmExecutionResult.denied:
-        return Status.executionDenied
-      case ConfirmExecutionResult.confirmationPending:
-        return Status.confirmationPending
-      case ConfirmExecutionResult.disabled:
-        return Status.executionDisabled
-      case ConfirmExecutionResult.approved:
-        return Status.ok
-    }
-  }
-}
-
-namespace ConfirmExecution {
-  export const type = new RequestType<ConfirmExecutionParams, ConfirmExecutionResult, void>('eslint/confirmESLintExecution')
-}
-
 namespace ShowOutputChannel {
   export const type = new NotificationType0('eslint/showOutputChannel')
 }
 
 const exitCalled = new NotificationType<[number, string]>('eslint/exitCalled')
-
-interface WorkspaceFolderItem extends QuickPickItem {
-  folder: VWorkspaceFolder
-}
 
 async function pickFolder(folders: ReadonlyArray<VWorkspaceFolder>, placeHolder: string): Promise<VWorkspaceFolder | undefined> {
   if (folders.length === 1) {
@@ -342,7 +313,7 @@ async function pickFolder(folders: ReadonlyArray<VWorkspaceFolder>, placeHolder:
 function createDefaultConfiguration(): void {
   const folders = Workspace.workspaceFolders
   if (!folders) {
-    Window.showErrorMessage('An ESLint configuration can only be generated if VS Code is opened on a workspace folder.')
+    void Window.showErrorMessage('An ESLint configuration can only be generated if VS Code is opened on a workspace folder.')
     return
   }
   const noConfigFolders = folders.filter(folder => {
@@ -356,13 +327,13 @@ function createDefaultConfiguration(): void {
   })
   if (noConfigFolders.length === 0) {
     if (folders.length === 1) {
-      Window.showInformationMessage('The workspace already contains an ESLint configuration file.')
+      void Window.showInformationMessage('The workspace already contains an ESLint configuration file.')
     } else {
-      Window.showInformationMessage('All workspace folders already contain an ESLint configuration file.')
+      void Window.showInformationMessage('All workspace folders already contain an ESLint configuration file.')
     }
     return
   }
-  pickFolder(noConfigFolders, 'Select a workspace folder to generate a ESLint configuration for').then(async (folder) => {
+  void pickFolder(noConfigFolders, 'Select a workspace folder to generate a ESLint configuration for').then(async (folder) => {
     if (!folder) {
       return
     }
@@ -411,214 +382,39 @@ function computeValidate(textDocument: TextDocument): Validate {
   return Validate.off
 }
 
-const eslintExecutionKey = 'eslintLibraries'
-let eslintExecutionState: ESLintExecutionState
-
-const eslintAlwaysAllowExecutionKey = 'eslintAlwaysAllowExecution'
-let eslintAlwaysAllowExecutionState: boolean = false
-
-const sessionState: Map<string, ExecutionParams> = new Map()
-const disabledLibraries: Set<string> = new Set()
-
-type ResourceInfo = {
-  status: Status
-  executionInfo: ExecutionInfo | undefined
-}
-const resource2ResourceInfo: Map<string, ResourceInfo> = new Map()
-let globalStatus: Status | undefined
-
-type ExecutionInfo = {
-  params: ExecutionParams
-  result: ConfirmExecutionResult
-  editorErrorUri: Uri | undefined
-  diagnostics: DiagnosticCollection
-  codeActionProvider: Disposable | undefined
-}
-let lastExecutionInfo: ExecutionInfo | undefined
-const libraryPath2ExecutionInfo: Map<string, ExecutionInfo> = new Map()
-const workspaceFolder2ExecutionInfos: Map<string, ExecutionInfo[]> = new Map()
-
-function updateExecutionInfo(params: ExecutionParams, result: ConfirmExecutionResult): void {
-  let value: ExecutionInfo | undefined = libraryPath2ExecutionInfo.get(params.libraryPath)
-  if (value === undefined) {
-    value = {
-      params: { libraryPath: params.libraryPath, scope: params.scope },
-      result: result,
-      editorErrorUri: undefined,
-      codeActionProvider: undefined,
-      diagnostics: Languages.createDiagnosticCollection()
-    }
-    libraryPath2ExecutionInfo.set(params.libraryPath, value)
-  } else {
-    value.result = result
-  }
-}
-
-function updateStatusInfo(param: StatusParams): void {
-  globalStatus = param.state
-  let info = resource2ResourceInfo.get(param.uri)
-  if (info === undefined) {
-    info = {
-      executionInfo: undefined,
-      status: param.state
-    }
-    resource2ResourceInfo.set(param.uri, info)
-  } else {
-    info.status = param.state
-  }
-}
-
-function getExecutionInfo(doc: Document | undefined, strict: boolean): ExecutionInfo | undefined {
-  if (doc == undefined) {
-    return undefined
-  }
-  const info = resource2ResourceInfo.get(doc.uri)
-  if (info !== undefined) {
-    return info.executionInfo
-  }
-  if (!strict) {
-    const folder = Workspace.getWorkspaceFolder(doc.uri)
-    if (folder !== undefined) {
-      const values = workspaceFolder2ExecutionInfos.get(folder.uri.toString())
-      return values && values[0]
-    }
-  }
-  return undefined
-}
-
-function clearInfo(info: ExecutionInfo): void {
-  info.diagnostics.clear()
-  if (info.codeActionProvider !== undefined) {
-    info.codeActionProvider.dispose()
-  }
-}
-
-function clearDiagnosticState(params: ExecutionParams): void {
-  const info = libraryPath2ExecutionInfo.get(params.libraryPath)
-  if (info === undefined) {
-    return
-  }
-  clearInfo(info)
-}
-
-function clearAllDiagnosticState(): void {
-  // Make a copy
-  for (const info of Array.from(libraryPath2ExecutionInfo.values())) {
-    clearInfo(info)
-  }
-}
-
-async function askForLibraryConfirmation(client: LanguageClient | undefined, context: ExtensionContext, params: ExecutionParams, update: undefined | (() => void)): Promise<void> {
-  sessionState.set(params.libraryPath, params)
-
-  // Reevaluate state and cancel since the information message is async
-  const libraryUri = Uri.file(params.libraryPath)
-  const folder = Workspace.getWorkspaceFolder(libraryUri.toString())
-
-  interface ConfirmMessageItem extends MessageItem {
-    value: ConfirmationSelection
+function parseRulesCustomizations(rawConfig: unknown): RuleCustomization[] {
+  if (!rawConfig || !Array.isArray(rawConfig)) {
+    return []
   }
 
-  let message: string
-  if (folder !== undefined) {
-    let relativePath = libraryUri.toString().substr(folder.uri.toString().length + 1)
-    const mainPath = '/lib/api.js'
-    if (relativePath.endsWith(mainPath)) {
-      relativePath = relativePath.substr(0, relativePath.length - mainPath.length)
-    }
-    message = `The ESLint extension will use '${relativePath}' for validation, which is installed locally in folder '${folder.name}'. Do you allow the execution of this ESLint version including all plugins and configuration files it will load on your behalf?\n\nPress 'Allow Everywhere' to remember the choice for all workspaces. Use 'Disable' to disable ESLint for this session.`
-  } else {
-    message = params.scope === 'global'
-      ? `The ESLint extension will use a globally installed ESLint library for validation. Do you allow the execution of this ESLint version including all plugins and configuration files it will load on your behalf?\n\nPress 'Always Allow' to remember the choice for all workspaces. Use 'Cancel' to disable ESLint for this session.`
-      : `The ESLint extension will use a locally installed ESLint library for validation. Do you allow the execution of this ESLint version including all plugins and configuration files it will load on your behalf?\n\nPress 'Always Allow' to remember the choice for all workspaces. Use 'Cancel' to disable ESLint for this session.`
-  }
-
-  const messageItems: ConfirmMessageItem[] = [
-    { title: 'Allow Everywhere', value: ConfirmationSelection.alwaysAllow },
-    { title: 'Allow', value: ConfirmationSelection.allow },
-    { title: 'Deny', value: ConfirmationSelection.deny },
-    { title: 'Disable', value: ConfirmationSelection.disable }
-  ]
-  const item = await Window.showInformationMessage<ConfirmMessageItem>(message, ...messageItems)
-
-  // Dialog got canceled.
-  if (item === undefined) {
-    return
-  }
-
-  if (item.value === ConfirmationSelection.disable) {
-    disabledLibraries.add(params.libraryPath)
-    updateExecutionInfo(params, ConfirmExecutionResult.disabled)
-    clearDiagnosticState(params)
-  } else {
-    disabledLibraries.delete(params.libraryPath)
-    if (item.value === ConfirmationSelection.allow || item.value === ConfirmationSelection.deny) {
-      const value = item.value === ConfirmationSelection.allow ? true : false
-      eslintExecutionState.libs[params.libraryPath] = value
-      context.globalState.update(eslintExecutionKey, eslintExecutionState)
-      updateExecutionInfo(params, value ? ConfirmExecutionResult.approved : ConfirmExecutionResult.denied)
-      clearDiagnosticState(params)
-    } else if (item.value === ConfirmationSelection.alwaysAllow) {
-      eslintAlwaysAllowExecutionState = true
-      context.globalState.update(eslintAlwaysAllowExecutionKey, eslintAlwaysAllowExecutionState)
-      updateExecutionInfo(params, ConfirmExecutionResult.approved)
-      clearAllDiagnosticState()
-    }
-  }
-
-  update && update()
-  client && client.sendNotification(DidChangeConfigurationNotification.type.method, { settings: {} })
-}
-
-async function resetLibraryConfirmations(client: LanguageClient | undefined, context: ExtensionContext, update: undefined | (() => void)): Promise<void> {
-  interface ESLintQuickPickItem extends QuickPickItem {
-    kind: 'all' | 'allConfirmed' | 'allRejected' | 'session' | 'alwaysAllow'
-  }
-  const items: ESLintQuickPickItem[] = [
-    { label: 'Reset ESLint library decisions for this workspace', kind: 'session' },
-    { label: 'Reset all ESLint library decisions', kind: 'all' }
-  ]
-  if (eslintAlwaysAllowExecutionState) {
-    items.splice(1, 0, { label: 'Reset Always Allow all ESlint libraries decision', kind: 'alwaysAllow' })
-  }
-  const selectedIdx = await Window.showQuickpick(items.map(o => o.label), 'Clear library confirmations')
-  if (selectedIdx == -1) {
-    return
-  }
-  let selected = items[selectedIdx]
-  switch (selected.kind) {
-    case 'all':
-      eslintExecutionState.libs = {}
-      eslintAlwaysAllowExecutionState = false
-      break
-    case 'alwaysAllow':
-      eslintAlwaysAllowExecutionState = false
-      break
-    case 'session':
-      if (sessionState.size === 1) {
-        const param = sessionState.values().next().value
-        await askForLibraryConfirmation(client, context, param, update)
-        return
-      } else {
-        for (const lib of sessionState.keys()) {
-          delete eslintExecutionState.libs[lib]
-        }
+  return rawConfig.map(rawValue => {
+    if (typeof rawValue.severity === 'string' && typeof rawValue.rule === 'string') {
+      return {
+        severity: rawValue.severity,
+        rule: rawValue.rule,
       }
-      break
+    }
+
+    return undefined
+  }).filter((value): value is RuleCustomization => !!value)
+}
+
+// Copied from LSP libraries. We should have a flag in the client to know whether the
+// client runs in debugger mode.
+function isInDebugMode(): boolean {
+  const debugStartWith: string[] = ['--debug=', '--debug-brk=', '--inspect=', '--inspect-brk=']
+  const debugEquals: string[] = ['--debug', '--debug-brk', '--inspect', '--inspect-brk']
+  let args: string[] = (process as any).execArgv
+  if (args) {
+    return args.some((arg) => {
+      return debugStartWith.some(value => arg.startsWith(value)) ||
+        debugEquals.some(value => arg === value)
+    })
   }
-  context.globalState.update(eslintExecutionKey, eslintExecutionState)
-  context.globalState.update(eslintAlwaysAllowExecutionKey, eslintAlwaysAllowExecutionState)
-  disabledLibraries.clear()
-  libraryPath2ExecutionInfo.clear()
-  resource2ResourceInfo.clear()
-  workspaceFolder2ExecutionInfos.clear()
-  update && update()
-  client && client.sendNotification(DidChangeConfigurationNotification.type.method, { settings: {} })
+  return false
 }
 
 export function activate(context: ExtensionContext) {
-  eslintExecutionState = context.globalState.get<ESLintExecutionState>(eslintExecutionKey, { libs: {} })
-  eslintAlwaysAllowExecutionState = context.globalState.get<boolean>(eslintAlwaysAllowExecutionKey, false)
 
   function didOpenTextDocument(textDocument: TextDocument) {
     if (activated) {
@@ -656,18 +452,15 @@ export function activate(context: ExtensionContext) {
     let doc = Workspace.getDocument(bufnr)
     const enabled = Workspace.getConfiguration('eslint', doc ? doc.uri : undefined).get('enable', true)
     if (!enabled) {
-      Window.showInformationMessage(`ESLint is not running because the deprecated setting 'eslint.enable' is set to false. Remove the setting and use the extension disablement feature.`)
+      void Window.showInformationMessage(`ESLint is not running because the deprecated setting 'eslint.enable' is set to false. Remove the setting and use the extension disablement feature.`)
     } else {
-      Window.showInformationMessage('ESLint is not running. By default only TypeScript and JavaScript files are validated. If you want to validate other file types please specify them in the \'eslint.probe\' setting.')
+      void Window.showInformationMessage('ESLint is not running. By default only TypeScript and JavaScript files are validated. If you want to validate other file types please specify them in the \'eslint.probe\' setting.')
     }
   }
   onActivateCommands = [
     Commands.registerCommand('eslint.executeAutofix', notValidating),
     Commands.registerCommand('eslint.showOutputChannel', notValidating),
-    Commands.registerCommand('eslint.manageLibraryExecution', notValidating),
-    Commands.registerCommand('eslint.resetLibraryExecution', () => {
-      resetLibraryConfirmations(undefined, context, undefined)
-    })
+    Commands.registerCommand('eslint.restart', notValidating)
   ]
 
   context.subscriptions.push(
@@ -675,83 +468,6 @@ export function activate(context: ExtensionContext) {
   )
   context.subscriptions.push(new EslintTask())
   configurationChanged()
-}
-
-interface InspectData<T> {
-  globalValue?: T
-  workspaceValue?: T
-  workspaceFolderValue?: T
-}
-interface MigrationElement<T> {
-  changed: boolean
-  value: T | undefined
-}
-
-interface MigrationData<T> {
-  global: MigrationElement<T>
-  workspace: MigrationElement<T>
-  workspaceFolder: MigrationElement<T>
-}
-
-interface CodeActionsOnSaveMap {
-  'source.fixAll'?: boolean
-  'source.fixAll.eslint'?: boolean
-  [key: string]: boolean | undefined
-}
-
-type CodeActionsOnSave = CodeActionsOnSaveMap | string[] | null
-
-namespace CodeActionsOnSave {
-  export function isExplicitlyDisabled(setting: CodeActionsOnSave | undefined): boolean {
-    if (setting === undefined || setting === null || Array.isArray(setting)) {
-      return false
-    }
-    return setting['source.fixAll.eslint'] === false
-  }
-
-  export function getSourceFixAll(setting: CodeActionsOnSave): boolean | undefined {
-    if (setting === null) {
-      return undefined
-    } if (Array.isArray(setting)) {
-      return setting.includes('source.fixAll') ? true : undefined
-    } else {
-      return setting['source.fixAll']
-    }
-  }
-
-  export function getSourceFixAllESLint(setting: CodeActionsOnSave): boolean | undefined {
-    if (setting === null) {
-      return undefined
-    } else if (Array.isArray(setting)) {
-      return setting.includes('source.fixAll.eslint') ? true : undefined
-    } else {
-      return setting['source.fixAll.eslint']
-    }
-  }
-
-  export function setSourceFixAllESLint(setting: CodeActionsOnSave, value: boolean | undefined): void {
-    // If the setting is mistyped do nothing.
-    if (setting === null) {
-      return
-    } else if (Array.isArray(setting)) {
-      const index = setting.indexOf('source.fixAll.eslint')
-      if (value === true) {
-        if (index === -1) {
-          setting.push('source.fixAll.eslint')
-        }
-      } else {
-        if (index >= 0) {
-          setting.splice(index, 1)
-        }
-      }
-    } else {
-      setting['source.fixAll.eslint'] = value
-    }
-  }
-}
-
-interface LanguageSettings {
-  'editor.codeActionsOnSave'?: CodeActionsOnSave
 }
 
 function realActivate(context: ExtensionContext): void {
@@ -765,7 +481,23 @@ function realActivate(context: ExtensionContext): void {
   const stopped = 'ESLint server stopped.'
   statusBarItem.text = 'ESLint'
 
-  function updateStatusBar(status: Status, isValidated: boolean) {
+  const documentStatus: Map<string, Status> = new Map()
+
+  function updateDocumentStatus(params: StatusParams): void {
+    documentStatus.set(params.uri, params.state)
+    updateStatusBar(params.uri)
+  }
+
+  function updateStatusBar(uri: string | undefined) {
+    const status = function () {
+      if (serverRunning === false) {
+        return Status.error
+      }
+      // if (uri === undefined) {
+      //   uri = Window.activeTextEditor?.document.uri.toString()
+      // }
+      return (uri !== undefined ? documentStatus.get(uri) : undefined) ?? Status.ok
+    }()
     let text: string = 'ESLint'
     switch (status) {
       case Status.ok:
@@ -777,166 +509,48 @@ function realActivate(context: ExtensionContext): void {
       case Status.error:
         text = 'Eslint error'
         break
-      case Status.executionDenied:
-        text = 'Eslint denied'
-        break
-      case Status.executionDisabled:
-        text = 'Eslint disabled'
-        break
-      case Status.confirmationPending:
-        text = 'ESLint not approved or denied yet.'
-        break
       default:
         text = ''
     }
     statusBarItem.text = serverRunning === undefined ? starting : text
     const alwaysShow = Workspace.getConfiguration('eslint').get('alwaysShowStatus', false)
-    if (alwaysShow || eslintAlwaysAllowExecutionState === true || status !== Status.ok || (status === Status.ok && isValidated)) {
+    if (alwaysShow || status !== Status.ok) {
       statusBarItem.show()
     } else {
       statusBarItem.hide()
     }
   }
 
-  const flaggedLanguages = new Set(['javascript', 'javascriptreact', 'typescript', 'typescriptreact'])
-  async function updateStatusBarAndDiagnostics(): Promise<void> {
-    let doc = await Workspace.document
-
-    function clearLastExecutionInfo(): void {
-      if (lastExecutionInfo === undefined) {
-        return
-      }
-      if (lastExecutionInfo.codeActionProvider !== undefined) {
-        lastExecutionInfo.codeActionProvider.dispose()
-        lastExecutionInfo.codeActionProvider = undefined
-      }
-      if (lastExecutionInfo.editorErrorUri !== undefined) {
-        lastExecutionInfo.diagnostics.delete(lastExecutionInfo.editorErrorUri.toString())
-        lastExecutionInfo.editorErrorUri = undefined
-      }
-      lastExecutionInfo = undefined
+  function sanitize<T, D>(value: T, type: 'bigint' | 'boolean' | 'function' | 'number' | 'object' | 'string' | 'symbol' | 'undefined', def: D): T | D {
+    if (Array.isArray(value)) {
+      return value.filter(item => typeof item === type) as unknown as T
+    } else if (typeof value !== type) {
+      return def
     }
-
-    function handleEditor(doc: Document): void {
-      const uri = doc.uri
-
-      const resourceInfo = resource2ResourceInfo.get(uri)
-      if (resourceInfo === undefined) {
-        return
-      }
-      const info = resourceInfo.executionInfo
-      if (info === undefined) {
-        return
-      }
-
-      if (info.result === ConfirmExecutionResult.confirmationPending && info.editorErrorUri?.toString() !== uri.toString()) {
-        const range = doc.getWordRangeAtPosition(Position.create(0, 0)) ?? Range.create(0, 0, 0, 0)
-        const diagnostic = Diagnostic.create(
-          range,
-          'ESLint is disabled since its execution has not been approved or denied yet. Use :CocCommand eslint.showOutputChannel to open the approval dialog.', VDiagnosticSeverity.Warning
-        )
-        diagnostic.source = 'eslint'
-        const errorUri = doc.uri
-
-        info.diagnostics.set(errorUri, [diagnostic])
-        if (info.editorErrorUri !== undefined) {
-          info.diagnostics.delete(info.editorErrorUri.toString())
-        }
-        info.editorErrorUri = Uri.parse(errorUri)
-        if (info.codeActionProvider !== undefined) {
-          info.codeActionProvider.dispose()
-        }
-        info.codeActionProvider = Languages.registerCodeActionProvider([{ pattern: Uri.parse(errorUri).fsPath }], {
-          provideCodeActions: (_document, _range, context) => {
-            for (const diag of context.diagnostics) {
-              if (diag === diagnostic) {
-                const result: CodeAction = {
-                  title: 'ESLint: Manage Library Execution',
-                  kind: CodeActionKind.QuickFix
-                }
-                result.isPreferred = true
-                result.command = {
-                  title: 'Manage Library Execution',
-                  command: 'eslint.manageLibraryExecution',
-                  arguments: [info.params]
-                }
-                return [result]
-              }
-            }
-            return []
-          }
-        }, 'eslint-library')
-      }
-
-      lastExecutionInfo = info
-    }
-
-    function findApplicableStatus(editor: Document | undefined): [Status, boolean] {
-      let candidates: IterableIterator<ExecutionInfo> | ExecutionInfo[] | undefined
-      if (editor !== undefined) {
-        const resourceInfo = resource2ResourceInfo.get(editor.uri)
-        if (resourceInfo !== undefined) {
-          return [resourceInfo.status, true]
-        }
-        const workspaceFolder = Workspace.getWorkspaceFolder(editor.uri)
-        if (workspaceFolder !== undefined) {
-          candidates = workspaceFolder2ExecutionInfos.get(workspaceFolder.uri.toString())
-        }
-      }
-      if (candidates === undefined) {
-        candidates = libraryPath2ExecutionInfo.values()
-      }
-      let result: ConfirmExecutionResult | undefined
-      for (const info of candidates) {
-        if (result === undefined) {
-          result = info.result
-        } else {
-          if (info.result === ConfirmExecutionResult.confirmationPending) {
-            result = info.result
-            break
-          } else if (info.result === ConfirmExecutionResult.denied || info.result === ConfirmExecutionResult.disabled) {
-            result = info.result
-          }
-        }
-      }
-      return [result !== undefined ? ConfirmExecutionResult.toStatus(result) : Status.ok, false]
-    }
-
-    const executionInfo = getExecutionInfo(doc, true)
-    if (lastExecutionInfo !== executionInfo) {
-      clearLastExecutionInfo()
-    }
-
-    if (doc && doc.attached && flaggedLanguages.has(doc.filetype)) {
-      handleEditor(doc)
-    } else {
-      clearLastExecutionInfo()
-    }
-
-    const [status, isValidated] = findApplicableStatus(doc)
-    updateStatusBar(status, isValidated)
+    return value
   }
 
   const serverModule = context.asAbsolutePath('lib/server.js')
   // Uri.joinPath(context.extensionUri, 'server', 'out', 'eslintServer.js').fsPath
   const eslintConfig = Workspace.getConfiguration('eslint')
-  const runtime = eslintConfig.get('runtime', undefined)
-  const debug = eslintConfig.get('debug')
-  const argv = eslintConfig.get<string[]>('execArgv', [])
-  const nodeEnv = eslintConfig.get('nodeEnv', null)
+  const debug = sanitize(eslintConfig.get<boolean>('debug', false) ?? false, 'boolean', false)
+  const runtime = sanitize(eslintConfig.get<string | null>('runtime', null) ?? undefined, 'string', undefined)
+  const execArgv = sanitize(eslintConfig.get<string[] | null>('runtime.execArgv', null) ?? undefined, 'string', undefined)
+  const nodeEnv = sanitize(eslintConfig.get('nodeEnv', null) ?? undefined, 'string', undefined)
 
   let env: { [key: string]: string | number | boolean } | undefined
   if (debug) {
     env = env || {}
     env.DEBUG = 'eslint:*,-eslint:code-path'
   }
-  if (nodeEnv) {
+  if (nodeEnv !== undefined) {
     env = env || {}
     env.NODE_ENV = nodeEnv
   }
+  const debugArgv = ['--nolazy', '--inspect=6011']
   const serverOptions: ServerOptions = {
-    run: { module: serverModule, transport: TransportKind.ipc, runtime, options: { cwd: Workspace.cwd, env, execArgv: argv } },
-    debug: { module: serverModule, transport: TransportKind.ipc, runtime, options: { execArgv: argv.concat(['--nolazy', '--inspect=6011']), cwd: process.cwd(), env } }
+    run: { module: serverModule, transport: TransportKind.ipc, runtime, options: { execArgv, cwd: process.cwd(), env } },
+    debug: { module: serverModule, transport: TransportKind.ipc, runtime, options: { execArgv: execArgv !== undefined ? execArgv.concat(debugArgv) : debugArgv, cwd: process.cwd(), env } }
   }
 
   let defaultErrorHandler: ErrorHandler
@@ -945,7 +559,7 @@ function realActivate(context: ExtensionContext): void {
   const packageJsonFilter: DocumentFilter = { scheme: 'file', pattern: '**/package.json' }
   const configFileFilter: DocumentFilter = { scheme: 'file', pattern: '**/.eslintr{c.js,c.yaml,c.yml,c,c.json}' }
   const syncedDocuments: Map<string, TextDocument> = new Map<string, TextDocument>()
-  const confirmationSemaphore: Semaphore<ConfirmExecutionResult> = new Semaphore<ConfirmExecutionResult>(1)
+
   const supportedQuickFixKinds: Set<string> = new Set([CodeActionKind.Source, CodeActionKind.SourceFixAll, `${CodeActionKind.SourceFixAll}.eslint`, CodeActionKind.QuickFix])
   const clientOptions: LanguageClientOptions = {
     documentSelector: [{ scheme: 'file' }, { scheme: 'untitled' }],
@@ -979,40 +593,40 @@ function realActivate(context: ExtensionContext): void {
       }
     },
     middleware: {
-      didOpen: (document, next) => {
+      didOpen: async (document, next) => {
         if (Workspace.match([packageJsonFilter], document) || Workspace.match([configFileFilter], document) || computeValidate(document) !== Validate.off) {
-          next(document)
-          syncedDocuments.set(document.uri, document)
-          return
+          const result = next(document)
+          syncedDocuments.set(document.uri.toString(), document)
+          return result
         }
       },
-      didChange: (event, next) => {
-        if (syncedDocuments.has(event.textDocument.uri)) {
-          next(event)
+      didChange: async (event, next) => {
+        if (syncedDocuments.has(event.textDocument.uri.toString())) {
+          return next(event)
         }
       },
-      willSave: (event, next) => {
-        if (syncedDocuments.has(event.document.uri)) {
-          next(event)
+      willSave: async (event, next) => {
+        if (syncedDocuments.has(event.document.uri.toString())) {
+          return next(event)
         }
       },
       willSaveWaitUntil: (event, next) => {
-        if (syncedDocuments.has(event.document.uri)) {
+        if (syncedDocuments.has(event.document.uri.toString())) {
           return next(event)
         } else {
           return Promise.resolve([])
         }
       },
-      didSave: (document, next) => {
-        if (syncedDocuments.has(document.uri)) {
-          next(document)
+      didSave: async (document, next) => {
+        if (syncedDocuments.has(document.uri.toString())) {
+          return next(document)
         }
       },
-      didClose: (document, next) => {
-        const uri = document.uri
+      didClose: async (document, next) => {
+        const uri = document.uri.toString()
         if (syncedDocuments.has(uri)) {
           syncedDocuments.delete(uri)
-          next(document)
+          return next(document)
         }
       },
       provideCodeActions: (document, range, context, token, next): ProviderResult<(Command | CodeAction)[]> => {
@@ -1034,16 +648,16 @@ function realActivate(context: ExtensionContext): void {
         if (context.only === undefined && eslintDiagnostics.length === 0) {
           return []
         }
-        const newContext: CodeActionContext = Object.assign({}, context, { diagnostics: eslintDiagnostics } as CodeActionContext)
+        const newContext: CodeActionContext = Object.assign({}, context, { diagnostics: eslintDiagnostics })
         return next(document, range, newContext, token)
       },
       workspace: {
         didChangeWatchedFile: (event, next) => {
           probeFailed.clear()
-          next(event)
+          return next(event)
         },
-        didChangeConfiguration: (sections, next) => {
-          next(sections)
+        didChangeConfiguration: async (sections, next) => {
+          return next(sections)
         },
         configuration: async (params, _token, _next): Promise<any[]> => {
           if (params.items === undefined) {
@@ -1051,16 +665,21 @@ function realActivate(context: ExtensionContext): void {
           }
           const result: (ConfigurationSettings | null)[] = []
           for (const item of params.items) {
+            console.error('config item:', item)
             if (item.section || !item.scopeUri) {
               result.push(null)
               continue
             }
-            const resource = item.scopeUri
-            const config = Workspace.getConfiguration('eslint', resource)
-            const workspaceFolder = Workspace.getWorkspaceFolder(resource)
+            const resource = Uri.parse(item.scopeUri)
+            console.error('resource:', resource.fsPath, item.scopeUri)
+            const config = Workspace.getConfiguration('eslint', resource.fsPath)
+            const workspaceFolder = resource.scheme === 'untitled'
+              ? Workspace.workspaceFolders !== undefined ? Workspace.workspaceFolders[0] : undefined
+              : Workspace.getWorkspaceFolder(resource.fsPath)
             const settings: ConfigurationSettings = {
               validate: Validate.off,
               packageManager: config.get('packageManager', 'npm'),
+              useESLintClass: config.get('useESLintClass', false),
               codeActionOnSave: {
                 enable: false,
                 mode: CodeActionsOnSaveMode.all
@@ -1069,8 +688,9 @@ function realActivate(context: ExtensionContext): void {
               quiet: config.get('quiet', false),
               onIgnoredFiles: ESLintSeverity.from(config.get<string>('onIgnoredFiles', ESLintSeverity.off)),
               options: config.get('options', {}),
+              rulesCustomizations: parseRulesCustomizations(config.get('rules.customizations')),
               run: config.get('run', 'onType'),
-              nodePath: config.get('nodePath', null),
+              nodePath: config.get<string | undefined>('nodePath', undefined) ?? null,
               workingDirectory: undefined,
               workspaceFolder: undefined,
               codeAction: {
@@ -1090,6 +710,7 @@ function realActivate(context: ExtensionContext): void {
               settings.format = !!config.get('format.enable', false)
               settings.codeActionOnSave.enable = !!config.get('autoFixOnSave', false) //readCodeActionsOnSaveSetting(document)
               settings.codeActionOnSave.mode = CodeActionsOnSaveMode.from(config.get('codeActionsOnSave.mode', CodeActionsOnSaveMode.all))
+              settings.codeActionOnSave.rules = CodeActionsOnSaveRules.from(config.get('codeActionsOnSave.rules', null))
             }
             if (workspaceFolder !== undefined) {
               settings.workspaceFolder = {
@@ -1183,7 +804,7 @@ function realActivate(context: ExtensionContext): void {
   try {
     client = new LanguageClient('ESLint', serverOptions, clientOptions)
   } catch (err) {
-    Window.showErrorMessage(`The ESLint extension couldn't be started. See the ESLint output channel for details.`)
+    void Window.showErrorMessage(`The ESLint extension couldn't be started. See the ESLint output channel for details.`)
     return
   }
 
@@ -1254,22 +875,22 @@ function realActivate(context: ExtensionContext): void {
       client.info(stopped)
       serverRunning = false
     }
-    updateStatusBar(globalStatus ?? serverRunning === false ? Status.error : Status.ok, true)
+    updateStatusBar(undefined)
   })
-  client.onReady().then(() => {
+
+  const readyHandler = () => {
     client.onNotification(ShowOutputChannel.type, () => {
       client.outputChannel.show()
     })
 
     client.onNotification(StatusNotification.type, (params) => {
-      updateStatusInfo(params)
-      updateStatusBarAndDiagnostics()
+      updateDocumentStatus(params)
     })
 
     client.onNotification(exitCalled, (params) => {
       serverCalledProcessExit = true
       client.error(`Server process exited with code ${params[0]}. This usually indicates a misconfigured ESLint setup.`, params[1])
-      Window.showErrorMessage(`ESLint server shut down itself. See 'ESLint' output channel for details.`, { title: 'Open Output', id: 1 }).then((value) => {
+      void Window.showErrorMessage(`ESLint server shut down itself. See 'ESLint' output channel for details.`, { title: 'Open Output', id: 1 }).then((value) => {
         if (value !== undefined && value.id === 1) {
           client.outputChannel.show()
         }
@@ -1295,17 +916,7 @@ function realActivate(context: ExtensionContext): void {
         ].join('\n'))
       }
 
-      let resourceInfo: ResourceInfo | undefined = resource2ResourceInfo.get(params.document.uri)
-      if (resourceInfo === undefined) {
-        resourceInfo = {
-          status: Status.warn,
-          executionInfo: undefined
-        }
-        resource2ResourceInfo.set(params.document.uri, resourceInfo)
-      } else {
-        resourceInfo.status = Status.warn
-      }
-      updateStatusBarAndDiagnostics()
+      updateDocumentStatus({ uri: params.document.uri, state: Status.error })
       return {}
     })
 
@@ -1351,8 +962,8 @@ function realActivate(context: ExtensionContext): void {
         }
         if (!state.workspaces[workspaceFolder.uri.toString()]) {
           state.workspaces[workspaceFolder.uri.toString()] = true
-          context.globalState.update(key, state)
-          Window.showInformationMessage(`Failed to load the ESLint library for the document ${uri.fsPath}. See the output for more information.`, outputItem).then((item) => {
+          void context.globalState.update(key, state)
+          void Window.showInformationMessage(`Failed to load the ESLint library for the document ${uri.fsPath}. See the output for more information.`, outputItem).then((item) => {
             if (item && item.id === 1) {
               client.outputChannel.show(true)
             }
@@ -1368,8 +979,8 @@ function realActivate(context: ExtensionContext): void {
 
         if (!state.global) {
           state.global = true
-          context.globalState.update(key, state)
-          Window.showInformationMessage(`Failed to load the ESLint library for the document ${uri.fsPath}. See the output for more information.`, outputItem).then((item) => {
+          void context.globalState.update(key, state)
+          void Window.showInformationMessage(`Failed to load the ESLint library for the document ${uri.fsPath}. See the output for more information.`, outputItem).then((item) => {
             if (item && item.id === 1) {
               client.outputChannel.show(true)
             }
@@ -1379,8 +990,8 @@ function realActivate(context: ExtensionContext): void {
       return {}
     })
 
-    client.onRequest(OpenESLintDocRequest.type, (params) => {
-      Commands.executeCommand('vscode.open', Uri.parse(params.url))
+    client.onRequest(OpenESLintDocRequest.type, async (params) => {
+      await Commands.executeCommand('vscode.open', Uri.parse(params.url))
       return {}
     })
 
@@ -1393,67 +1004,9 @@ function realActivate(context: ExtensionContext): void {
         }
       }
     })
+  }
 
-    client.onRequest(ConfirmExecution.type, async (params): Promise<ConfirmExecutionResult> => {
-      return confirmationSemaphore.lock(async () => {
-        try {
-          sessionState.set(params.libraryPath, params)
-          let result: ConfirmExecutionResult | undefined
-          if (disabledLibraries.has(params.libraryPath)) {
-            result = ConfirmExecutionResult.disabled
-          } else {
-            const state = eslintExecutionState.libs[params.libraryPath]
-            if (state === true || state === false) {
-              clearDiagnosticState(params)
-              result = state ? ConfirmExecutionResult.approved : ConfirmExecutionResult.denied
-            } else if (eslintAlwaysAllowExecutionState === true) {
-              clearDiagnosticState(params)
-              result = ConfirmExecutionResult.approved
-
-            }
-          }
-          result = result ?? ConfirmExecutionResult.confirmationPending
-          let executionInfo: ExecutionInfo | undefined = libraryPath2ExecutionInfo.get(params.libraryPath)
-          if (executionInfo === undefined) {
-            executionInfo = {
-              params: params,
-              result: result,
-              codeActionProvider: undefined,
-              diagnostics: Languages.createDiagnosticCollection(),
-              editorErrorUri: undefined
-            }
-            libraryPath2ExecutionInfo.set(params.libraryPath, executionInfo)
-            const workspaceFolder = Workspace.getWorkspaceFolder(params.uri)
-            if (workspaceFolder !== undefined) {
-              const key = workspaceFolder.uri.toString()
-              let infos = workspaceFolder2ExecutionInfos.get(key)
-              if (infos === undefined) {
-                infos = []
-                workspaceFolder2ExecutionInfos.set(key, infos)
-              }
-              infos.push(executionInfo)
-            }
-          } else {
-            executionInfo.result = result
-          }
-          let resourceInfo = resource2ResourceInfo.get(params.uri)
-          if (resourceInfo === undefined) {
-            resourceInfo = {
-              status: ConfirmExecutionResult.toStatus(result),
-              executionInfo: executionInfo
-            }
-            resource2ResourceInfo.set(params.uri, resourceInfo)
-          } else {
-            resourceInfo.status = ConfirmExecutionResult.toStatus(result)
-          }
-          updateStatusBarAndDiagnostics()
-          return result
-        } catch (err) {
-          return ConfirmExecutionResult.denied
-        }
-      })
-    })
-  })
+  client.onReady().then(readyHandler).catch((error) => client.error(`On ready failed`, error))
 
   if (onActivateCommands) {
     onActivateCommands.forEach(command => command.dispose())
@@ -1463,22 +1016,12 @@ function realActivate(context: ExtensionContext): void {
   context.subscriptions.push(
     client.start(),
     events.on('BufEnter', () => {
-      updateStatusBarAndDiagnostics()
-    }),
-    Workspace.registerTextDocumentContentProvider('eslint-error', {
-      provideTextDocumentContent: () => {
-        return [
-          'ESLint is disabled since its execution has not been approved or rejected yet.',
-          '',
-          'When validating a file using ESLint, the ESLint NPM library will load customization files and code from your workspace',
-          'and will execute it. If you do not trust the content in your workspace you should answer accordingly on the corresponding',
-          'approval dialog.'
-        ].join('\n')
-      }
+      updateStatusBar(undefined)
     }),
     Workspace.onDidCloseTextDocument((document) => {
       const uri = document.uri.toString()
-      resource2ResourceInfo.delete(uri)
+      documentStatus.delete(uri)
+      updateStatusBar(undefined)
     }),
     Commands.registerCommand('eslint.executeAutofix', async () => {
       const doc = await Workspace.document
@@ -1495,69 +1038,24 @@ function realActivate(context: ExtensionContext): void {
       }
       await client.onReady()
       client.sendRequest(ExecuteCommandRequest.type.method, params).then(undefined, () => {
-        Window.showErrorMessage('Failed to apply ESLint fixes to the document. Please consider opening an issue with steps to reproduce.')
+        void Window.showErrorMessage('Failed to apply ESLint fixes to the document. Please consider opening an issue with steps to reproduce.')
       })
     }),
     Commands.registerCommand('eslint.showOutputChannel', async () => {
-      let doc = await Workspace.document
-      const executionInfo = getExecutionInfo(doc, false)
-      if (executionInfo !== undefined && (executionInfo.result === ConfirmExecutionResult.confirmationPending || executionInfo.result === ConfirmExecutionResult.disabled)) {
-        await askForLibraryConfirmation(client, context, executionInfo.params, updateStatusBarAndDiagnostics)
-        return
-      }
-
-      if (globalStatus === Status.ok || globalStatus === Status.warn || globalStatus === Status.error) {
-        client.outputChannel.show()
-        return
-      }
-
-      if (globalStatus === Status.executionDenied) {
-        await resetLibraryConfirmations(client, context, updateStatusBarAndDiagnostics)
-        return
-      }
-
-      let candidate: string | undefined
-      let toRemove: Set<string> | Map<string, boolean> | undefined
-      if (globalStatus === Status.confirmationPending) {
-        if (libraryPath2ExecutionInfo.size === 1) {
-          candidate = libraryPath2ExecutionInfo.keys().next().value
-        }
-      }
-      if (globalStatus === Status.executionDisabled) {
-        if (disabledLibraries.size === 1) {
-          candidate = disabledLibraries.keys().next().value
-          toRemove = disabledLibraries
-        }
-      }
-
-      if (candidate !== undefined) {
-        if (sessionState.has(candidate)) {
-          if (toRemove !== undefined) {
-            toRemove.delete(candidate)
-          }
-          await askForLibraryConfirmation(client, context, sessionState.get(candidate)!, updateStatusBarAndDiagnostics)
-          return
-        }
-      }
       client.outputChannel.show()
     }),
-    Commands.registerCommand('eslint.resetLibraryExecution', () => {
-      resetLibraryConfirmations(client, context, updateStatusBarAndDiagnostics)
-    }),
-    Commands.registerCommand('eslint.manageLibraryExecution', async (params: ConfirmExecutionParams | undefined) => {
-      if (params !== undefined) {
-        await askForLibraryConfirmation(client, context, params, updateStatusBarAndDiagnostics)
+    Commands.registerCommand('eslint.restart', async () => {
+      await client.stop()
+      // Wait a little to free debugger port. Can not happen in production
+      // So we should add a dev flag.
+      const start = () => {
+        client.start()
+        client.onReady().then(readyHandler).catch((error) => client.error(`On ready failed`, error))
+      }
+      if (isInDebugMode()) {
+        setTimeout(start, 1000)
       } else {
-        let doc = await Workspace.document
-        const info = getExecutionInfo(doc, false)
-        if (info !== undefined) {
-          await askForLibraryConfirmation(client, context, info.params, updateStatusBarAndDiagnostics)
-        } else {
-          Window.showInformationMessage(
-            doc && doc.attached
-              ? 'No ESLint library execution information found for current buffer.'
-              : 'No ESLint library execution information found.')
-        }
+        start()
       }
     })
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -665,13 +665,11 @@ function realActivate(context: ExtensionContext): void {
           }
           const result: (ConfigurationSettings | null)[] = []
           for (const item of params.items) {
-            console.error('config item:', item)
             if (item.section || !item.scopeUri) {
               result.push(null)
               continue
             }
             const resource = Uri.parse(item.scopeUri)
-            console.error('resource:', resource.fsPath, item.scopeUri)
             const config = Workspace.getConfiguration('eslint', resource.fsPath)
             const workspaceFolder = resource.scheme === 'untitled'
               ? Workspace.workspaceFolders !== undefined ? Workspace.workspaceFolders[0] : undefined

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,10 +163,10 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-coc.nvim@^0.0.80:
-  version "0.0.80"
-  resolved "https://registry.yarnpkg.com/coc.nvim/-/coc.nvim-0.0.80.tgz#785145c382660db03f517f9b497900d95cbd0e4f"
-  integrity sha512-/3vTcnofoAYMrdENrlQmADTzfXX4+PZ0fiM10a39UA37dTR2dpIGi9O469kcIksuunLjToqWG8S45AGx/9wV7g==
+coc.nvim@^0.0.81-next.7:
+  version "0.0.81-next.7"
+  resolved "https://registry.yarnpkg.com/coc.nvim/-/coc.nvim-0.0.81-next.7.tgz#adbdb62034468ad1ae9dd27af8d1e87e64a219b6"
+  integrity sha512-/e8FUIpC97j6wbOy9V79s62aNBMXvMuUvA5LdIyd0Z0itaA+DND7jJIY9UwrRMkMg7BgwJgwVo13oOdMHrRMWQ==
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -779,19 +779,6 @@ vscode-jsonrpc@6.0.0:
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz#108bdb09b4400705176b957ceca9e0880e9b6d4e"
   integrity sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==
 
-vscode-jsonrpc@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
-  integrity sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==
-
-vscode-languageserver-protocol@3.15.3:
-  version "3.15.3"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz#3fa9a0702d742cf7883cb6182a6212fcd0a1d8bb"
-  integrity sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==
-  dependencies:
-    vscode-jsonrpc "^5.0.1"
-    vscode-languageserver-types "3.15.1"
-
 vscode-languageserver-protocol@3.16.0:
   version "3.16.0"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz#34135b61a9091db972188a07d337406a3cdbe821"
@@ -800,15 +787,10 @@ vscode-languageserver-protocol@3.16.0:
     vscode-jsonrpc "6.0.0"
     vscode-languageserver-types "3.16.0"
 
-vscode-languageserver-textdocument@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz#178168e87efad6171b372add1dea34f53e5d330f"
-  integrity sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==
-
-vscode-languageserver-types@3.15.1:
-  version "3.15.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz#17be71d78d2f6236d414f0001ce1ef4d23e6b6de"
-  integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==
+vscode-languageserver-textdocument@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.2.tgz#2f9f6bd5b5eb3d8e21424c0c367009216f016236"
+  integrity sha512-T7uPC18+f8mYE4lbVZwb3OSmvwTZm3cuFhrdx9Bn2l11lmp3SvSuSVjy2JtvrghzjAo4G6Trqny2m9XGnFnWVA==
 
 vscode-languageserver-types@3.16.0:
   version "3.16.0"
@@ -822,10 +804,10 @@ vscode-languageserver@7.0.0:
   dependencies:
     vscode-languageserver-protocol "3.16.0"
 
-vscode-uri@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.1.1.tgz#5aa1803391b6ebdd17d047f51365cf62c38f6e90"
-  integrity sha512-eY9jmGoEnVf8VE8xr5znSah7Qt1P/xsCdErz+g8HYZtJ7bZqKH5E3d+6oVNm1AC/c6IHUDokbmVXKOi4qPAC9A==
+vscode-uri@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.2.tgz#ecfd1d066cb8ef4c3a208decdbab9a8c23d055d0"
+  integrity sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA==
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
closes #117 

1. vscode-eslint 2.0 added settings migration, this is not ported
2. ConfirmExecution has been removed
3. `rulesCustomizations` supports
4. eslintServer.ts supports ESLint 8+, use the new `ESLint` https://eslint.org/docs/user-guide/migrating-to-7.0.0#deprecate-cliengine