### PR TITLE
fix: Wait for autofix to finish.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1054,7 +1054,7 @@ function realActivate(context: ExtensionContext): void {
         arguments: [textDocument]
       }
       await client.onReady()
-      client.sendRequest(ExecuteCommandRequest.type.method, params).then(undefined, () => {
+      await client.sendRequest(ExecuteCommandRequest.type.method, params).then(undefined, () => {
         void Window.showErrorMessage('Failed to apply ESLint fixes to the document. Please consider opening an issue with steps to reproduce.')
       })
     }),


### PR DESCRIPTION
I add executeAutofix set in my `BufWritePre` but I found out it ended after the buffer was written, returning in a wrongly saved file and a buffer still reported as modified.

Adding `await` fixes the issue.